### PR TITLE
Changing the DB from MongoClient to Mongoose

### DIFF
--- a/server/config/db.js
+++ b/server/config/db.js
@@ -9,9 +9,12 @@ const connectDB = async () => {
             useUnifiedTopology: true
         })
         .then((data) => {
-            console.log(`MongoDB connected with server: ${data.connection.host}`)
+            console.log('MongoDB connection successful');
+            console.log(`MongoDB connected with server: ${data.connection.host}`);
+        })
+        .catch((error) => {
+            console.log(`Error: ${error}`);
         });
-
 };
 
 module.exports = connectDB;

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -1,21 +1,17 @@
-const { MongoClient } = require("mongodb");
+const mongoose = require('mongoose');
 require('dotenv').config();
 
 const connectDB = async () => {
     const url = process.env.ATLAS_URI;
-    const client = new MongoClient(url, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true
-    });
-    try {
-        await client.connect();
-        console.log('Connection to MongoDB successful');
-    } catch (error) {
-        console.log("Cannot connect to MongoDB");
-        console.log(error);
-    } finally{
-        await client.close();
-    }
+    mongoose
+        .connect(url, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true
+        })
+        .then((data) => {
+            console.log(`MongoDB connected with server: ${data.connection.host}`)
+        });
+
 };
 
 module.exports = connectDB;


### PR DESCRIPTION
I decided to change the database by replacing MongoClient DB with Mongoose.
With MongoClient DB, I could not use any CRUD functions since the CRUD functions were written using Mongoose. 
I would get the error "`users.insertOne()` buffering timed out after 10000ms". I was able to fix this using Mongoose.

The database configuration does not change, however. 